### PR TITLE
新規登録/ログイン/ログアウトのロジック変更

### DIFF
--- a/app/controllers/LoginController.java
+++ b/app/controllers/LoginController.java
@@ -1,0 +1,75 @@
+package controllers;
+
+import models.User;
+import play.data.*;
+import play.db.jpa.Transactional;
+import play.i18n.*;
+import play.mvc.*;
+import services.UserService;
+
+import javax.inject.Inject;
+
+/**
+ * ログイン処理に関するコントローラ
+ *
+ * @author arapiku
+ */
+@Transactional
+public class LoginController extends Controller {
+
+    private final FormFactory formFactory;
+
+    @Inject
+    private UserService userService;
+
+    @Inject
+    private MessagesApi messagesApi;
+
+    @Inject
+    public LoginController(FormFactory formFactory) {
+        this.formFactory = formFactory;
+    }
+
+    public Result index() {
+        return Results.ok(views.html.index.render());
+    }
+
+    /**
+     * ログインフォーム画面の出力
+     *
+     * @return
+     */
+    public Result loginForm() {
+        Form<User> f = formFactory.form(User.class);
+
+        return Results.ok(views.html.login.render(f));
+    }
+
+    /**
+     * ログイン処理
+     *
+     * @return
+     */
+    public Result login() {
+        Form<User> f = formFactory.form(User.class).bindFromRequest();
+        String userName = f.get().userName;
+        String password = f.get().password;
+        // ここに null or empty チェック必要ぽい
+        if (userName == null || userName.isEmpty() || password == null || password.isEmpty()) {
+            flash("error", messagesApi.get(Lang.forCode("ja"), "login.errors.400.nullorempty"));
+            return Results.badRequest(views.html.login.render(f));
+        }
+
+        User user = userService.findByUserNameAndPassword(userName, password);
+        System.out.println(user);
+
+        if (user == null) {
+            flash("error", messagesApi.get(Lang.forCode("ja"),"login.errors.400.nouser"));
+            return Results.badRequest(views.html.login.render(f));
+        }
+
+        session("userID", String.valueOf(user.userId));
+        return redirect("/top");
+    }
+
+}

--- a/app/controllers/LogoutController.java
+++ b/app/controllers/LogoutController.java
@@ -1,0 +1,25 @@
+package controllers;
+
+import play.mvc.*;
+
+import static play.mvc.Controller.session;
+import static play.mvc.Results.redirect;
+
+/**
+ * ログアウト処理
+ *
+ * @author arapiku
+ */
+public class LogoutController {
+
+    /**
+     * セッション破棄とトップページへのリダイレクト
+     *
+     * @return
+     */
+    public Result logout() {
+        session().remove("userID");
+        return redirect("/");
+    }
+
+}

--- a/app/controllers/TicketController.java
+++ b/app/controllers/TicketController.java
@@ -9,14 +9,6 @@ import play.mvc.*;
  */
 public class TicketController extends Controller {
 
-    /**
-     * トップページの表示
-     * （今は表示しか機能させてないのでのちのち修正必要）
-     *
-     * @return
-     */
-    public Result index() {
-        return Results.ok(views.html.index.render());
-    }
+
     
 }

--- a/app/dtos/UserDTO.java
+++ b/app/dtos/UserDTO.java
@@ -11,10 +11,10 @@ import play.data.validation.Constraints;
 public class UserDTO {
 
     @Constraints.Required
-    public String UUID;
+    public String userName;
 
     @Constraints.Required
-    public String name;
+    public String nickName;
 
     @Constraints.Required
     public String email;
@@ -22,11 +22,12 @@ public class UserDTO {
     @Constraints.Required
     public String thumbnailPath;
 
-    public User duplicateUserInfo(String UUID, String name, String email, String thumbnailPath) {
+    public User duplicateUserInfo(String userName, String nickName, String email, String password, String thumbnailPath) {
         User user = new User();
-        user.UUID = UUID;
-        user.name = name;
+        user.userName = userName;
+        user.nickName = nickName;
         user.email = email;
+        user.password = password;
         user.thumbnailPath = thumbnailPath;
         return user;
     }

--- a/app/models/User.java
+++ b/app/models/User.java
@@ -21,8 +21,12 @@ public class User {
     /** アクセストークン */
     public String UUID;
 
+    @Column(unique = true)
     /** ユーザー名 */
-    public String name;
+    public String userName;
+
+    /** ニックネーム */
+    public String nickName;
 
     /** メールアドレス */
     public String email;
@@ -58,4 +62,115 @@ public class User {
     @JsonIgnore
     public List<UserReview> userReviews;
 
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getUUID() {
+        return UUID;
+    }
+
+    public void setUUID(String UUID) {
+        this.UUID = UUID;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getNickName() {
+        return nickName;
+    }
+
+    public void setNickName(String nickName) {
+        this.nickName = nickName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getThumbnailPath() {
+        return thumbnailPath;
+    }
+
+    public void setThumbnailPath(String thumbnailPath) {
+        this.thumbnailPath = thumbnailPath;
+    }
+
+    public String getCardNo() {
+        return cardNo;
+    }
+
+    public void setCardNo(String cardNo) {
+        this.cardNo = cardNo;
+    }
+
+    public String getCardMaxAgeMonth() {
+        return cardMaxAgeMonth;
+    }
+
+    public void setCardMaxAgeMonth(String cardMaxAgeMonth) {
+        this.cardMaxAgeMonth = cardMaxAgeMonth;
+    }
+
+    public String getCardMaxAgeYear() {
+        return cardMaxAgeYear;
+    }
+
+    public void setCardMaxAgeYear(String cardMaxAgeYear) {
+        this.cardMaxAgeYear = cardMaxAgeYear;
+    }
+
+    public String getCardName() {
+        return cardName;
+    }
+
+    public void setCardName(String cardName) {
+        this.cardName = cardName;
+    }
+
+    public Integer getCardCVC() {
+        return cardCVC;
+    }
+
+    public void setCardCVC(Integer cardCVC) {
+        this.cardCVC = cardCVC;
+    }
+
+    public List<Ticket> getTickets() {
+        return tickets;
+    }
+
+    public void setTickets(List<Ticket> tickets) {
+        this.tickets = tickets;
+    }
+
+    public List<UserReview> getUserReviews() {
+        return userReviews;
+    }
+
+    public void setUserReviews(List<UserReview> userReviews) {
+        this.userReviews = userReviews;
+    }
 }

--- a/app/repositories/UserRepository.java
+++ b/app/repositories/UserRepository.java
@@ -6,6 +6,7 @@ import play.Logger;
 import play.db.jpa.JPAApi;
 import play.libs.Json;
 
+import javax.persistence.NoResultException;
 import java.util.List;
 
 /**
@@ -32,8 +33,32 @@ public class UserRepository {
         return jpa.em().createQuery("SELECT u FROM User u", User.class).getResultList();
     }
 
+    /**
+     * ログインのためのユーザー名とパスワード照合
+     *
+     * @param userName
+     * @param password
+     * @return
+     */
+    public User findByUserNameAndPassword(String userName, String password) {
+        try {
+            return jpa.em().createQuery("SELECT u FROM User u WHERE u.userName = :username AND u.password = :password", User.class)
+                .setParameter("username", userName)
+                .setParameter("password", password)
+                .getSingleResult();
+        } catch (NoResultException n) {
+            return null;
+        }
+    }
+
+    /**
+     * ユーザーの新規登録
+     *
+     * @param user
+     */
     public void registUser(User user) {
         jpa.em().persist(user);
         Logger.debug("ユーザーが登録されました： {}", Json.toJson(user));
     }
+
 }

--- a/app/services/UserService.java
+++ b/app/services/UserService.java
@@ -25,6 +25,21 @@ public class UserService {
         return userRepository.findAll();
     }
 
+    /**
+     * UserRepositoryのfindByUserNameAndPassword()を呼び出す
+     * その際にuserNameとpasswordを引数として渡す
+     *
+     * @param userName
+     * @param password
+     * @return
+     */
+    public User findByUserNameAndPassword(String userName, String password) { return userRepository.findByUserNameAndPassword(userName, password); }
+
+    /**
+     * userRepositoryのregistUser()を呼び出す
+     *
+     * @param user
+     */
     public void registUser(User user) {
         userRepository.registUser(user);
     }

--- a/app/views/common/header.scala.html
+++ b/app/views/common/header.scala.html
@@ -14,17 +14,17 @@
             <div class="global-menu__ticket-create">
                 <a href="" class="global-menu__ticket-create-btn">チケットの作成</a>
             </div>
-            @if(CommonHelper.isBlank(session().get(Pac4jConstants.SESSION_ID))) {
-            <div class="global-menu__signup">
-                <a href="@routes.SignUpController.index()" class="global-menu__signup-btn">新規会員登録</a>
-            </div>
-            <div class="global-menu__login">
-                <a href="" class="global-menu__login-btn">ログイン</a>
-            </div>
+            @if(CommonHelper.isBlank(session().get("userID"))) {
+                <div class="global-menu__signup">
+                    <a href="@routes.SignUpController.index()" class="global-menu__signup-btn">新規会員登録</a>
+                </div>
+                <div class="global-menu__login">
+                    <a href="@routes.LoginController.loginForm()" class="global-menu__login-btn">ログイン</a>
+                </div>
             } else {
-            <div class="global-menu__logout">
-                <a href="@org.pac4j.play.routes.LogoutController.logout()" class="global-menu__login-btn">ログアウト</a>
-            </div>
+                <div class="global-menu__logout">
+                    <a href="@routes.LogoutController.logout()" class="global-menu__login-btn">ログアウト</a>
+                </div>
             }
         </nav>
     </div>

--- a/app/views/input.scala.html
+++ b/app/views/input.scala.html
@@ -1,0 +1,22 @@
+@import views.html.common.header
+
+@(form: Form[models.User])
+
+@header()
+
+@main("Sign Up Page") {
+    @if(flash.containsKey("unique_error")) {
+        <p style="color: #ff0000;">@flash.get("unique_error")</p>
+    }
+
+    @helper.form(action = routes.SignUpController.input()) {
+        @helper.CSRF.formField
+        @helper.inputText(form("userName"))
+        @helper.inputText(form("nickName"))
+        @helper.inputText(form("email"))
+        @helper.inputText(form("password"))
+        @helper.inputText(form("thumbnailPath"))
+        <input type="submit" value="送信">
+    }
+
+}

--- a/app/views/login.scala.html
+++ b/app/views/login.scala.html
@@ -1,0 +1,19 @@
+@import views.html.common.header
+
+@(form: Form[models.User])
+
+@header()
+
+@main("Login Page") {
+    @if(flash.containsKey("error")) {
+        <p style="color: #ff0000;">@flash.get("error")</p>
+    }
+
+    @helper.form(action = routes.LoginController.login) {
+        @helper.CSRF.formField
+        @helper.inputText(form("userName"))
+        @helper.inputText(form("password"))
+        <input type="submit" value="ログイン">
+    }
+
+}

--- a/app/views/signup.scala.html
+++ b/app/views/signup.scala.html
@@ -3,6 +3,6 @@
 @header()
 
 @main("Sign Up Page") {
-    <p><a href="@routes.SignUpController.signUp()">TWITTER</a></p>
+    <p><a href="@routes.SignUpController.accessTwitter()">TWITTER</a></p>
     @*<p><a href="@routes.SignUpController.signUp()">FACEBOOK</a></p>*@
 }

--- a/app/views/top.scala.html
+++ b/app/views/top.scala.html
@@ -1,11 +1,7 @@
-@(profiles: List[org.pac4j.core.profile.CommonProfile])
-
 @import views.html.common.header
 
 @header()
 
 @main("Top Page with Login") {
     <p>ログインしたやで</p>
-    <p>プロフィールやで</p>
-    @profiles
 }

--- a/conf/messages
+++ b/conf/messages
@@ -7,3 +7,7 @@ client.errors.default=クライアントエラーが発生しました：{0}
 
 login.errors.401=ログイン認証が必要です
 login.errors.403=リソースへのアクセスが許可されていません
+login.errors.400.nullorempty=ユーザー名かパスワードが空です。値を入力してください。
+login.errors.400.nouser=ユーザー名かパスワードが間違っています。再度入力してください。
+
+signup.errors.400.unique=その名前はすでに使われております。別の名前を入力してください。

--- a/conf/routes
+++ b/conf/routes
@@ -1,10 +1,14 @@
-GET        /                    controllers.TicketController.index
+GET         /                      controllers.LoginController.index
+GET         /login                 controllers.LoginController.loginForm
+POST        /login/login           controllers.LoginController.login
 ## OAuth
-GET        /signup              controllers.SignUpController.index
-GET        /signup/login        controllers.SignUpController.signUp
-GET        /top                 controllers.SignUpController.top
-GET        /callback            org.pac4j.play.CallbackController.callback()
-GET        /logout              org.pac4j.play.LogoutController.logout()
+GET         /signup                controllers.SignUpController.index
+GET         /signup/twitter        controllers.SignUpController.accessTwitter
+POST        /signup/input          controllers.SignUpController.input
+GET         /top                   controllers.SignUpController.top
+GET         /callback              org.pac4j.play.CallbackController.callback()
+#GET         /logout                org.pac4j.play.LogoutController.logout()
+GET         /logout                controllers.LogoutController.logout
 
 # Map static resources from the /public folder to the /assets URL path
-GET        /assets/*file        controllers.Assets.versioned(path="/public", file: Asset)
+GET         /assets/*file          controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
- キャッシュを用いず、セッションを用いる
- emailとpasswordの入力を要する
- 会員登録時/ログイン時に入力画面を用意
- ログイン時userIDをセッションに持たせる
- ログアウト時セッションを破棄する 