### PR TITLE
チケットオーナーが購入済みチケットに遷移できないバグを回避

### DIFF
--- a/app/repositories/PurchasedTicketRepository.java
+++ b/app/repositories/PurchasedTicketRepository.java
@@ -77,7 +77,7 @@ public class PurchasedTicketRepository {
      * @return
      */
     public PurchasedTicket findByTicketIdAndUserId(Long purchasedTicketId, Long userId) {
-        return jpa.em().createQuery("SELECT p FROM PurchasedTicket p WHERE p.purchasedTicketId = :purchasedTicketId AND p.buyer.userId = :userId", PurchasedTicket.class)
+        return jpa.em().createQuery("SELECT p FROM PurchasedTicket p WHERE p.purchasedTicketId = :purchasedTicketId AND p.buyer.userId = :userId OR p.ticket.user.userId = :userId", PurchasedTicket.class)
             .setParameter("purchasedTicketId", purchasedTicketId)
             .setParameter("userId", userId)
             .getSingleResult();


### PR DESCRIPTION
## URL
- https://trello.com/c/bSxaurlP/59-%E8%B3%BC%E5%85%A5%E6%B8%88%E3%81%BF%E3%83%81%E3%82%B1%E3%83%83%E3%83%88%E3%82%92%E3%83%81%E3%82%B1%E3%83%83%E3%83%88%E3%82%AA%E3%83%BC%E3%83%8A%E3%83%BC%E3%81%8C%E5%8F%82%E7%85%A7%E3%81%A7%E3%81%8D%E3%81%AA%E3%81%84

## 概要
- チケットオーナーが購入済みチケットに遷移できなかった
- repositoryのロジックを修正